### PR TITLE
Fix a bug: a string created by "new" should destroyed by "delete"

### DIFF
--- a/minios/click.cc
+++ b/minios/click.cc
@@ -163,7 +163,7 @@ router_thread(void *thread_data)
 	ri->f_stop = 1;
 
 	LOG("Driver stopped, closing router_thread");
-	free(config);
+	delete config;
 	free(rid);
 }
 


### PR DESCRIPTION
Fix a bug: a string created by "operator new" should be destroyed by "delete"

I found this bug when I configured with --enable-dmalloc which will alloc memory with an extra chunk at the beginning of the allocated memory for tracking memory usage  when calling "operator new" and "operator new[]". This bug causes minios crash since "free" gets a parameter which is not the beginning address of the allocated memory.
